### PR TITLE
fix: start language server with addon manager

### DIFF
--- a/client/src/addon_manager/registration.ts
+++ b/client/src/addon_manager/registration.ts
@@ -8,6 +8,7 @@ import RelativeTime from "dayjs/plugin/relativeTime";
 import { git, setupGit } from "./services/git.service";
 import { GIT_DOWNLOAD_URL } from "./config";
 import { NotificationLevels } from "./types/webvue";
+import * as languageServer from "../languageserver";
 
 dayjs.extend(RelativeTime);
 
@@ -40,6 +41,13 @@ export async function activate(context: vscode.ExtensionContext) {
                 );
                 logger.add(fileLogger);
                 await fileLogger.logStart();
+            }
+            // Start language server if it is not already
+            // We depend on it to apply config modifications
+            if (!languageServer.defaultClient) {
+                logger.debug("Starting language server");
+                await languageServer.createClient(context);
+                logger.debug("Language server has started");
             }
 
             // Check if git is installed

--- a/client/src/languageserver.ts
+++ b/client/src/languageserver.ts
@@ -78,6 +78,12 @@ function registerCustomCommands(context: ExtensionContext) {
     }));
 }
 
+/** Creates a new {@link LuaClient} and starts it. */
+export const createClient = (context: ExtensionContext) => {
+    defaultClient = new LuaClient(context, [{ language: 'lua' }])
+    defaultClient.start();
+}
+
 class LuaClient {
 
     public client: LanguageClient;
@@ -248,10 +254,7 @@ export function activate(context: ExtensionContext) {
 
         // Untitled files go to a default client.
         if (!defaultClient) {
-            defaultClient = new LuaClient(context, [
-                { language: 'lua' }
-            ]);
-            defaultClient.start();
+            createClient(context);
             return;
         }
     }


### PR DESCRIPTION
This fixes an issue where the addon manager is opened before a `.lua` file. This resulted in the language server not being started yet and the addon manager could not request the language server to apply configuration modifications.

Closes #119