### PR TITLE
Add typescript to devDependencies

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,8 @@
 			},
 			"devDependencies": {
 				"@types/node": "^17.0.35",
-				"@types/vscode": "^1.70.0"
+				"@types/vscode": "^1.70.0",
+				"typescript": "^5.4.5"
 			},
 			"engines": {
 				"vscode": "^1.70.0"
@@ -436,6 +437,19 @@
 			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
 			"engines": {
 				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/util-deprecate": {

--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^17.0.35",
-		"@types/vscode": "^1.70.0"
+		"@types/vscode": "^1.70.0",
+		"typescript": "^5.4.5"
 	}
 }


### PR DESCRIPTION
`npm run build` relies on the typescript compiler `tsc` but it is not listed in either the package.json files.