### PR TITLE
fix: accept relative paths in `Lua.workspace.library`

### DIFF
--- a/client/src/addon_manager/services/settings.service.ts
+++ b/client/src/addon_manager/services/settings.service.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import { getConfig, setConfig } from "../../languageserver";
 import { createChildLogger } from "./logging.service";
 import { LIBRARY_SETTING } from "../config";
@@ -25,7 +26,13 @@ export const getLibraryPaths = async (): Promise<
 
     for (const folder of vscode.workspace.workspaceFolders) {
         const libraries = await getConfig(LIBRARY_SETTING, folder.uri);
-        result.push({ folder, paths: libraries ?? [] });
+        const libraryPaths = libraries.map((libraryPath: string) => {
+            if (path.isAbsolute(libraryPath)) {
+                return libraryPath;
+            }
+            return path.join(folder.uri.fsPath, libraryPath);
+        })
+        result.push({ folder, paths: libraryPaths ?? [] });
     }
 
     return result;


### PR DESCRIPTION
### Description
allow to use relative paths in lua workspace library config `Lua.workspace.library`, example: 

```jsonc
{
  "Lua.workspace.library": [
    "../../Plugins/UnLua/Intermediate/IntelliSense"
  ]
}
```