### PR TITLE
Add `setConfig` public api

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -43,6 +43,9 @@ export function activate(context: vscode.ExtensionContext) {
     return {
         async reportAPIDoc(params: unknown) {
             await languageserver.reportAPIDoc(params);
+        },
+        async setConfig(changes: languageserver.ConfigChange[]) {
+            await languageserver.setConfig(changes);
         }
     };
 }


### PR DESCRIPTION
Following my question in https://github.com/LuaLS/lua-language-server/issues/2794 I would like to have `languageserver.setConfig` as a public api, so that third party extensions can edit LuaLS configurations, in the same fashion as LuaLS plugins.

This should make it easier to edit configurations without having to deal with `.luarc.json` and `settings.json`.
I'm requesting @carsakiller to review this.