### PR TITLE
Prune old tags from addons

### DIFF
--- a/client/src/addon_manager/models/addon.ts
+++ b/client/src/addon_manager/models/addon.ts
@@ -60,6 +60,7 @@ export class Addon {
         await this.getEnabled();
 
         if (this.#installed) {
+            await git.fetch(["origin", "--prune", "--prune-tags"]);
             tags = (
                 await moduleGit.tags([
                     "--sort=-taggerdate",


### PR DESCRIPTION
Fixes issues where a tag is deleted from an addon submodule but the local LLS-Addons clone does not prune it.

Fixes https://github.com/LuaLS/LLS-Addons/issues/171