### PR TITLE
filter .DS_Store file from addons list

### DIFF
--- a/client/src/addon_manager/commands/getAddons.ts
+++ b/client/src/addon_manager/commands/getAddons.ts
@@ -34,7 +34,7 @@ export default async (context: vscode.ExtensionContext) => {
     const CHUNK_SIZE = 30;
 
     // Get list of addons and sort them alphabetically
-    const addonList = Array.from(addonManager_service_1.default.addons.values()).filter(a => a.displayName !== '.DS_Store');
+    const addonList = Array.from(addonManager.addons.values());
     addonList.sort((a, b) => a.displayName.localeCompare(b.displayName));
 
     // Send addons to client in chunks

--- a/client/src/addon_manager/commands/getAddons.ts
+++ b/client/src/addon_manager/commands/getAddons.ts
@@ -34,7 +34,7 @@ export default async (context: vscode.ExtensionContext) => {
     const CHUNK_SIZE = 30;
 
     // Get list of addons and sort them alphabetically
-    const addonList = Array.from(addonManager.addons.values());
+    const addonList = Array.from(addonManager_service_1.default.addons.values()).filter(a => a.displayName !== '.DS_Store');
     addonList.sort((a, b) => a.displayName.localeCompare(b.displayName));
 
     // Send addons to client in chunks

--- a/client/src/addon_manager/services/addonManager.service.ts
+++ b/client/src/addon_manager/services/addonManager.service.ts
@@ -36,7 +36,7 @@ class AddonManager {
         if (addons) {
             addons = addons.filter((a) => !ignoreList.includes(a.name));
         }
-        if (!addons) {
+        if (!addons || addons.length === 0) {
             localLogger.warn("No addons found in installation folder");
             return;
         }

--- a/client/src/addon_manager/services/addonManager.service.ts
+++ b/client/src/addon_manager/services/addonManager.service.ts
@@ -33,11 +33,13 @@ class AddonManager {
 
         const ignoreList = [".DS_Store"];
         let addons = await filesystem.readDirectory(installLocation);
+        if (addons) {
+            addons = addons.filter((a) => !ignoreList.includes(a.name));
+        }
         if (!addons) {
             localLogger.warn("No addons found in installation folder");
             return;
         }
-        addons = addons.filter((a) => !ignoreList.includes(a.name));
         for (const addon of addons) {
             this.addons.set(addon.name, new Addon(addon.name, addon.uri));
             localLogger.verbose(`Found ${addon.name}`);

--- a/client/src/addon_manager/services/addonManager.service.ts
+++ b/client/src/addon_manager/services/addonManager.service.ts
@@ -31,9 +31,14 @@ class AddonManager {
             });
         }
 
-        const addons = await filesystem.readDirectory(installLocation);
-
-        for (const addon of addons ?? []) {
+        const ignoreList = [".DS_Store"];
+        let addons = await filesystem.readDirectory(installLocation);
+        if (!addons) {
+            localLogger.warn("No addons found in installation folder");
+            return;
+        }
+        addons = addons.filter((a) => !ignoreList.includes(a.name));
+        for (const addon of addons) {
             this.addons.set(addon.name, new Addon(addon.name, addon.uri));
             localLogger.verbose(`Found ${addon.name}`);
         }


### PR DESCRIPTION
The Addon Manager stopped working after a .DS_Store file popped up in the addons directory, indicating the following error:

```[2024-08-27 21:02:37] |   ERROR   |     Filesystem     | Error: ENOTDIR: not a directory, stat '/Users/<user>/Library/Application Support/Code/User/globalStorage/sumneko.lua/addonManager/addons/.DS_Store/module'```

Tested after adding the code change and verified Addon Manager successfully loaded.