### PR TITLE
add: enable addons using placeholder

### DIFF
--- a/client/src/addon_manager/models/addon.ts
+++ b/client/src/addon_manager/models/addon.ts
@@ -173,10 +173,7 @@ export class Addon {
      * @param libraryPaths An array of paths from the `Lua.workspace.library` setting.
      */
     public checkIfEnabled(libraryPaths: string[]) {
-        const regex = new RegExp(
-            `[/\\\\]+sumneko.lua[/\\\\]+addonManager[/\\\\]+addons[/\\\\]+${this.name}`,
-            "g"
-        );
+        const regex = new RegExp(`${this.name}\/module\/library`, "g");
 
         const index = libraryPaths.findIndex((path) => regex.test(path));
         return index !== -1;
@@ -207,7 +204,10 @@ export class Addon {
         return folderStates;
     }
 
-    public async enable(folder: vscode.WorkspaceFolder) {
+    public async enable(
+        folder: vscode.WorkspaceFolder,
+        installLocation: vscode.Uri
+    ) {
         const librarySetting = ((await getConfig(
             LIBRARY_SETTING,
             folder.uri
@@ -240,7 +240,11 @@ export class Addon {
         }
 
         // Apply addon settings
-        const libraryUri = vscode.Uri.joinPath(this.uri, "module", "library");
+        const libraryPath = vscode.Uri.joinPath(
+            this.uri,
+            "module",
+            "library"
+        ).path.replace(installLocation.path, "${addons}");
 
         const configValues = await this.getConfigurationFile();
 
@@ -249,7 +253,7 @@ export class Addon {
                 {
                     action: "add",
                     key: LIBRARY_SETTING,
-                    value: filesystem.unixifyPath(libraryUri),
+                    value: libraryPath,
                     uri: folder.uri,
                 },
             ]);

--- a/client/src/addon_manager/services/settings.service.ts
+++ b/client/src/addon_manager/services/settings.service.ts
@@ -24,13 +24,7 @@ export const getLibraryPaths = async (): Promise<
 
     for (const folder of vscode.workspace.workspaceFolders) {
         const libraries = await getConfig(LIBRARY_SETTING, folder.uri);
-        const libraryPaths = libraries.map((libraryPath: string) => {
-            if (path.isAbsolute(libraryPath)) {
-                return libraryPath;
-            }
-            return path.join(folder.uri.fsPath, libraryPath);
-        })
-        result.push({ folder, paths: libraryPaths ?? [] });
+        result.push({ folder, paths: libraries });
     }
 
     return result;


### PR DESCRIPTION
The addon manager now uses [`${addon}` placeholder](https://github.com/LuaLS/lua-language-server/pull/2866) in paths when enabling addons.