### PR TITLE
Pass globalStorageUri as storagePath for server to find addons

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Pass storagePath option to server to resolve addon directory not found
 
 ## 3.11.0
 * `NEW` Added support for Japanese locale

--- a/client/src/languageserver.ts
+++ b/client/src/languageserver.ts
@@ -154,6 +154,7 @@ class LuaClient extends Disposable {
                 codeLensViewReferences: true,
                 fixIndents: true,
                 languageConfiguration: true,
+                storagePath: this.context.globalStorageUri.path,
             },
         };
 


### PR DESCRIPTION
This goes with https://github.com/LuaLS/lua-language-server/pull/2893 and should allow the server to stop hard coding the config paths for finding addons on different OSes.