### PR TITLE
fix: add `lua` to languages contribution points

### DIFF
--- a/package.json
+++ b/package.json
@@ -3236,6 +3236,15 @@
 		],
 		"languages": [
 			{
+				"id": "lua",
+				"extensions": [
+					".lua"
+				],
+				"aliases": [
+					"Lua"
+				]
+			},
+			{
 				"filenames": [
 					".luarc.json",
 					"config.json"


### PR DESCRIPTION
This PR fixes issue where files with `.lua` extension are not recognized by VS Code as Lua files.
This is done by adding a proper entry to the [`contributes.languages`](https://code.visualstudio.com/api/references/contribution-points#contributes.languages) field in the extension manifest (`package.json`) file. 

Unless the user added the `lua` language identifier via other means (e.g. installing other extensions which contributes the `lua` language identifier), without this entry in the extension manifest, all `.lua` files would be detected as plain text files, which causes `vscode-lua` to remain inactive eventhough a Lua file (`.lua`) is actively opened in the editor.

![2024-10-24 16-30-08](https://github.com/user-attachments/assets/f7193dfc-8435-4058-bf18-fd8884ce1b0b "vscode-lua is not activated when editing .lua files")
